### PR TITLE
Replace call to express.logger() middleware since it's no longer supported.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,10 @@
 /*
  * Module dependencies
  */
-var express = require('express')
-  , stylus = require('stylus')
-  , nib = require('nib')
+var express = require('express'),
+    logger = require('express-log'),
+    stylus = require('stylus'),
+    nib = require('nib')
 
 
 var app = express()
@@ -16,7 +17,7 @@ function compile(str, path) {
 
 app.set('views', __dirname + '/views')
 app.set('view engine', 'jade')
-app.use(express.logger('dev'))
+app.use(logger());
 app.use(stylus.middleware(
   { src: __dirname + '/public'
   , compile: compile

--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ var express = require('express'),
     stylus = require('stylus'),
     nib = require('nib')
 
-
 var app = express()
 
 function compile(str, path) {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "dependencies": {
     "express": "3.0.0alpha4",
+    "express-log": "^1.0.1",
     "nib": "^1.0.4",
     "stylus": "^0.49.1",
     "jade": "^1.7.0"


### PR DESCRIPTION
Instead, I've added an additional module from express-log and added a call to that in app.js
